### PR TITLE
Add Claude Code config syncing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ All install commands are safe to run multiple times (`relink: true` is set globa
 | `git.yaml` | `tools/git/gitconfig` | `~/.gitconfig` |
 | `ssh.yaml` | `ssh/config`, `ssh/authorized_keys`, `ssh/known_hosts_fixed`, `ssh/known_hosts_ansible` | `~/.ssh/...` |
 | `ssh-confd.yaml` | SSH daemon override config | `/etc/ssh/sshd_config.d/` (requires sudo) |
+| `claude.yaml` | `claude/settings.json`, `claude/CLAUDE.md`, `claude/statusline-command.sh` | `~/.claude/...` |
 
 ### Zsh Setup
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ ssh -T git@github.com
 The [git config](meta/configs/git.yaml) will link the following files:
 * [gitconfig](git/gitconfig) to `~/.gitconfig`
 
+# Claude Code
+The [claude config](meta/configs/claude.yaml) will:
+* Create `~/.claude/` if it doesn't exist
+* Clean broken symlinks from `~/.claude/`
+* Link the following files:
+  * [settings.json](claude/settings.json) to `~/.claude/settings.json`
+  * [CLAUDE.md](claude/CLAUDE.md) to `~/.claude/CLAUDE.md`
+  * [statusline-command.sh](claude/statusline-command.sh) to `~/.claude/statusline-command.sh`
+
 # Contents
 To create the charts below, run the following commands:
 ``` bash
@@ -170,6 +179,7 @@ meta/profiles
 ```
 meta/configs
 ├── bash.yaml
+├── claude.yaml
 ├── git.yaml
 ├── ssh-confd.yaml
 ├── ssh.yaml
@@ -178,20 +188,25 @@ meta/configs
 ## Dotfiles
 ```
 .
+├── CLAUDE.md
 ├── README.md
+├── claude
+│   ├── CLAUDE.md
+│   ├── settings.json
+│   └── statusline-command.sh
 ├── install-profile
 ├── install-standalone
 ├── shells
-│   ├── bash
-│   │   └── bashrc
-│   └── zsh
-│       ├── p10k.zsh
-│       └── zshrc
+│   ├── bash
+│   │   └── bashrc
+│   └── zsh
+│       ├── p10k.zsh
+│       └── zshrc
 ├── ssh
-│   ├── authorized_keys
-│   ├── config
-│   ├── known_hosts_ansible
-│   ├── known_hosts_fixed
+│   ├── authorized_keys
+│   ├── config
+│   ├── known_hosts_ansible
+│   └── known_hosts_fixed
 └── tools
     └── git
         └── gitconfig

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ The [claude config](meta/configs/claude.yaml) will:
   * [CLAUDE.md](claude/CLAUDE.md) to `~/.claude/CLAUDE.md`
   * [statusline-command.sh](claude/statusline-command.sh) to `~/.claude/statusline-command.sh`
 
+The `statusline-command.sh` script requires the following tools on your `PATH`:
+* `git` (for repository status)
+* `jq` (for JSON parsing)
+
 # Contents
 To create the charts below, run the following commands:
 ``` bash

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,0 +1,4 @@
+# Personal Claude Code Instructions
+
+## PR Workflow
+Before merging any PR, suggest running `/simplify` and `/security-review` on the changes.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "sh /home/nelson/.claude/statusline-command.sh"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(gh pr view*)",
+      "Bash(gh pr list*)",
+      "Bash(gh pr checks*)",
+      "Bash(gh pr diff*)",
+      "Bash(gh pr status*)",
+      "Bash(gh issue view*)",
+      "Bash(gh issue list*)",
+      "Bash(gh issue status*)",
+      "Bash(gh repo view*)",
+      "Bash(gh run view*)",
+      "Bash(gh run list*)",
+      "Bash(gh release view*)",
+      "Bash(gh release list*)"
+    ]
+  }
+}

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,7 +1,7 @@
 {
   "statusLine": {
     "type": "command",
-    "command": "sh /home/nelson/.claude/statusline-command.sh"
+    "command": "sh ~/.claude/statusline-command.sh"
   },
   "permissions": {
     "allow": [

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Claude Code status line — mirrors p10k prompt: user@host dir [git] | model ctx%
+input=$(cat)
+
+user=$(whoami)
+host=$(hostname -s)
+dir=$(echo "$input" | jq -r '.workspace.current_dir')
+
+# Shorten home directory to ~
+home_dir="$HOME"
+short_dir="${dir#$home_dir}"
+if [ "$short_dir" != "$dir" ]; then
+  short_dir="~$short_dir"
+else
+  short_dir="$dir"
+fi
+
+# Git branch and dirty status (skip optional locks)
+git_info=""
+if git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
+  branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || git -C "$dir" rev-parse --short HEAD 2>/dev/null)
+  dirty=$(git -C "$dir" status --porcelain --no-lock-index 2>/dev/null | head -1)
+  if [ -n "$dirty" ]; then
+    git_info=" [$branch *]"
+  else
+    git_info=" [$branch]"
+  fi
+fi
+
+# Model and context
+model=$(echo "$input" | jq -r '.model.display_name')
+ctx=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+if [ -n "$ctx" ]; then
+  ctx_display=" | ctx:$(printf '%.0f' "$ctx")%"
+else
+  ctx_display=""
+fi
+
+printf '%s@%s %s%s | %s%s' "$user" "$host" "$short_dir" "$git_info" "$model" "$ctx_display"

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -19,7 +19,7 @@ fi
 git_info=""
 if git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
   branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || git -C "$dir" rev-parse --short HEAD 2>/dev/null)
-  dirty=$(git -C "$dir" status --porcelain --no-lock-index 2>/dev/null | head -1)
+  dirty=$(git -C "$dir" status --porcelain --no-optional-locks 2>/dev/null | head -1)
   if [ -n "$dirty" ]; then
     git_info=" [$branch *]"
   else

--- a/meta/configs/claude.yaml
+++ b/meta/configs/claude.yaml
@@ -1,3 +1,6 @@
+- create:
+    - ~/.claude
+
 - link:
     ~/.claude/settings.json:
       path: claude/settings.json

--- a/meta/configs/claude.yaml
+++ b/meta/configs/claude.yaml
@@ -1,6 +1,9 @@
 - create:
     - ~/.claude
 
+- clean:
+    - ~/.claude
+
 - link:
     ~/.claude/settings.json:
       path: claude/settings.json

--- a/meta/configs/claude.yaml
+++ b/meta/configs/claude.yaml
@@ -1,0 +1,10 @@
+- link:
+    ~/.claude/settings.json:
+      path: claude/settings.json
+      relink: true
+    ~/.claude/CLAUDE.md:
+      path: claude/CLAUDE.md
+      relink: true
+    ~/.claude/statusline-command.sh:
+      path: claude/statusline-command.sh
+      relink: true

--- a/meta/profiles/workstation
+++ b/meta/profiles/workstation
@@ -1,3 +1,4 @@
 git
 ssh
 zsh
+claude


### PR DESCRIPTION
## Summary
- Adds `claude/` directory tracking `settings.json`, `CLAUDE.md`, and `statusline-command.sh`
- Adds `meta/configs/claude.yaml` dotbot config that creates `~/.claude/`, cleans broken symlinks, and symlinks the three files
- Adds `claude` to the workstation profile
- Updates README and CLAUDE.md documentation

## Test plan
- [x] Run `./install-standalone claude` on a fresh machine (with `~/.claude/` absent) and verify directory is created and symlinks are in place
- [x] Run `./install-standalone claude` again to confirm idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)