### PR TITLE
Refactor SSH configs into separate profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,10 @@ Initial setup:
 ```bash
 git clone https://github.com/nstoik/dotfiles.git --recursive
 cd dotfiles
-sudo chmod +x install-profile install-standalone
+sudo chmod +x install-profile install-standalone uninstall-profile
 ```
+
+`uninstall-profile` requires Python 3 and PyYAML (`pipx install pyyaml`).
 
 After pulling updates, sync submodules:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,19 +31,13 @@ Install individual configs:
 ./install-standalone ssh-confd-sudo  # add -sudo suffix for elevated privileges
 ```
 
-Skip optional SSH files via environment variables:
-```bash
-DOTBOT_SKIP_SSH_KNOWN_HOSTS_ANSIBLE_FILE=1 ./install-standalone ssh
-DOTBOT_SKIP_SSH_AUTHORIZED_FILE=1 ./install-standalone ssh
-```
-
 All install commands are safe to run multiple times (`relink: true` is set globally).
 
 ## Architecture
 
 ### Profile System
 
-- `meta/profiles/` — profile files listing which configs to apply (e.g., `server` applies git, ssh, zsh)
+- `meta/profiles/` — profile files listing which configs to apply (`client`, `server`, `workstation`)
 - `meta/configs/` — individual YAML config files consumed by Dotbot
 - `meta/base.yaml` — global Dotbot defaults (`relink: true`, `clean: ['~']`)
 - `meta/dotbot/` — Dotbot v1.24.0 as a git submodule
@@ -55,7 +49,9 @@ All install commands are safe to run multiple times (`relink: true` is set globa
 | `zsh.yaml` | `shells/zsh/zshrc`, `shells/zsh/p10k.zsh` | `~/.zshrc`, `~/.p10k.zsh` |
 | `bash.yaml` | `shells/bash/bashrc` | `~/.bashrc` |
 | `git.yaml` | `tools/git/gitconfig` | `~/.gitconfig` |
-| `ssh.yaml` | `ssh/config`, `ssh/authorized_keys`, `ssh/known_hosts_fixed`, `ssh/known_hosts_ansible` | `~/.ssh/...` |
+| `ssh.yaml` | `ssh/config`, `ssh/known_hosts_fixed` | `~/.ssh/config`, `~/.ssh/known_hosts_fixed` |
+| `ssh-authorized.yaml` | `ssh/authorized_keys` | `~/.ssh/authorized_keys` |
+| `ssh-known-hosts-ansible.yaml` | `ssh/known_hosts_ansible` | `~/.ssh/known_hosts_ansible` |
 | `ssh-confd.yaml` | SSH daemon override config | `/etc/ssh/sshd_config.d/` (requires sudo) |
 | `claude.yaml` | `claude/settings.json`, `claude/CLAUDE.md`, `claude/statusline-command.sh` | `~/.claude/...` |
 
@@ -70,7 +66,7 @@ The zshrc uses [zsh-snap](https://github.com/marlonrichert/zsh-snap) as a plugin
 Three separate known_hosts files are merged via SSH `Include`:
 - `known_hosts` — live/auto-updated by SSH
 - `known_hosts_fixed` — manually maintained in this repo
-- `known_hosts_ansible` — managed by the infrastructure repo (optional, skipped via env var)
+- `known_hosts_ansible` — managed by the infrastructure repo (applied via `ssh-known-hosts-ansible` config)
 
 ## Adding a New Config
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,11 @@ Install individual configs:
 ./install-standalone ssh-confd-sudo  # add -sudo suffix for elevated privileges
 ```
 
+Remove all symlinks for a profile (e.g. before switching profiles):
+```bash
+./uninstall-profile <profile>
+```
+
 All install commands are safe to run multiple times (`relink: true` is set globally).
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -12,8 +12,13 @@ It is configured in the [advanced mode](https://github.com/anishathalye/dotbot/w
 ``` bash
 > git clone https://github.com/nstoik/dotfiles.git --recursive
 > cd dotfiles
-> sudo chmod +x install-profile install-standalone
+> sudo chmod +x install-profile install-standalone uninstall-profile
 > chmod +x meta/dotbot/bin/dotbot
+```
+
+`uninstall-profile` requires Python 3 and PyYAML. Install PyYAML with:
+``` bash
+pipx install pyyaml
 ```
 
 After pulling updates on any machine, run the following to sync submodules to the correct commit:

--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ The [zsh config](meta/configs/zsh.yaml) will link the following files:
 The [ssh config](meta/configs/ssh.yaml) will link the following files:
 * [ssh config](ssh/config) to `~/.ssh/config`
 * [ssh known_hosts_fixed](ssh/known_hosts_fixed) to `~/.ssh/known_hosts_fixed`
-    * This file is used to store the known_hosts that is manually maintained.
-* [ssh known_hosts_ansible](ssh/known_hosts_ansible) to `~/.ssh/known_hosts_ansible`
-    * This file is used to store the known_hosts_ansible file that is managed by ansible and my [infrastructure repo](https://github.com/nstoik/infrastructure)
-    * This file will not be linked if the environment variable `DOTBOT_SKIP_SSH_KNOWN_HOSTS_ANSIBLE_FILE` is set.
-* [ssh authorized_keys](ssh/authorized_keys) to `~/.ssh/authorized_keys`
-    * This file is used to store the authorized_keys that are allowed to connect to the computer over ssh.
-    * This file will not be linked if the environment variable `DOTBOT_SKIP_SSH_AUTHORIZED_FILE` is set.
+    * Manually maintained known hosts.
+
+The [ssh-authorized config](meta/configs/ssh-authorized.yaml) will link:
+* [authorized_keys](ssh/authorized_keys) to `~/.ssh/authorized_keys`
+    * SSH keys permitted to connect to this machine.
+
+The [ssh-known-hosts-ansible config](meta/configs/ssh-known-hosts-ansible.yaml) will link:
+* [known_hosts_ansible](ssh/known_hosts_ansible) to `~/.ssh/known_hosts_ansible`
+    * Known hosts managed by Ansible and the [infrastructure repo](https://github.com/nstoik/infrastructure).
 
 ## WSL2: Bitwarden SSH Agent Bridge
 
@@ -133,22 +135,6 @@ ssh -T git@github.com
 - Ensure Bitwarden Desktop is unlocked and `npiperelay.exe` is on the Windows PATH.
 - Verify the named pipe exists from WSL2: `ls /mnt/c/Windows/System32/npiperelay.exe`
 
-## Examples
-``` bash
-# Normal installation
-~/.dotfiles$ ./install-standalone ssh
-
-# Skipping the Known_hosts_ansible file
-~/.dotfiles$ DOTBOT_SKIP_SSH_KNOWN_HOSTS_ANSIBLE_FILE=1 ./install-standalone ssh
-
-# Skipping the authorized_keys file
-~/.dotfiles$ DOTBOT_SKIP_SSH_AUTHORIZED_FILE=1 ./install-standalone ssh
-
-# Skipping both files
-~/.dotfiles$ DOTBOT_SKIP_SSH_KNOWN_HOSTS_ANSIBLE_FILE=1 DOTBOT_SKIP_SSH_AUTHORIZED_FILE=1 ./install-standalone ssh
-
-```
-
 
 # Git
 The [git config](meta/configs/git.yaml) will link the following files:
@@ -177,6 +163,7 @@ tree -I 'meta' .
 ## Profiles
 ```
 meta/profiles
+├── client
 ├── server
 └── workstation
 ```
@@ -186,7 +173,9 @@ meta/configs
 ├── bash.yaml
 ├── claude.yaml
 ├── git.yaml
+├── ssh-authorized.yaml
 ├── ssh-confd.yaml
+├── ssh-known-hosts-ansible.yaml
 ├── ssh.yaml
 └── zsh.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ You can also invoke a single configuration as a sudoer by adding `-sudo` to the 
 ~/.dotfiles$ ./install-standalone some-config-sudo some-other-config
 ```
 
+To remove all symlinks for a profile (e.g. before switching to a different profile):
+``` bash
+~/.dotfiles$ ./uninstall-profile <profile>
+```
+
 
 You can run these installation commands safely multiple times.
 

--- a/meta/configs/ssh-authorized.yaml
+++ b/meta/configs/ssh-authorized.yaml
@@ -2,4 +2,3 @@
     ~/.ssh/authorized_keys:
       create: true
       path: ssh/authorized_keys
-      force: true

--- a/meta/configs/ssh-authorized.yaml
+++ b/meta/configs/ssh-authorized.yaml
@@ -1,0 +1,5 @@
+- link:
+    ~/.ssh/authorized_keys:
+      create: true
+      path: ssh/authorized_keys
+      force: true

--- a/meta/configs/ssh-known-hosts-ansible.yaml
+++ b/meta/configs/ssh-known-hosts-ansible.yaml
@@ -1,0 +1,4 @@
+- link:
+    ~/.ssh/known_hosts_ansible:
+      create: true
+      path: ssh/known_hosts_ansible

--- a/meta/configs/ssh.yaml
+++ b/meta/configs/ssh.yaml
@@ -3,21 +3,6 @@
       create: true
       path: ssh/config
 
-    ~/.ssh/authorized_keys:
-      create: true
-      path: ssh/authorized_keys
-      force: true
-      # only copy the authorized_keys file if the environment variable
-      # DOTBOT_SKIP_SSH_AUTHORIZED_FILE is not set
-      if: '[ -z ${DOTBOT_SKIP_SSH_AUTHORIZED_FILE+x} ]'
-
     ~/.ssh/known_hosts_fixed:
       create: true
       path: ssh/known_hosts_fixed
-
-    ~/.ssh/known_hosts_ansible:
-      create: true
-      path: ssh/known_hosts_ansible
-      # only copy the Ansible known_hosts_ansible file if the environment variable
-      # DOTBOT_SKIP_SSH_KNOWN_HOSTS_ANSIBLE_FILE is not set
-      if: '[ -z ${DOTBOT_SKIP_SSH_KNOWN_HOSTS_ANSIBLE_FILE+x} ]'

--- a/meta/profiles/client
+++ b/meta/profiles/client
@@ -1,4 +1,3 @@
 git
-ssh
 ssh-authorized
 zsh

--- a/meta/profiles/workstation
+++ b/meta/profiles/workstation
@@ -1,5 +1,6 @@
 git
 ssh
+ssh-authorized
 ssh-known-hosts-ansible
 zsh
 claude

--- a/meta/profiles/workstation
+++ b/meta/profiles/workstation
@@ -1,4 +1,5 @@
 git
 ssh
+ssh-known-hosts-ansible
 zsh
 claude

--- a/uninstall-profile
+++ b/uninstall-profile
@@ -4,7 +4,12 @@ from __future__ import print_function
 
 import os
 import sys
-import yaml
+
+try:
+    import yaml
+except ImportError:
+    print("Error: PyYAML is required. Install with: pipx install pyyaml", file=sys.stderr)
+    sys.exit(1)
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 META_DIR = os.path.join(BASE_DIR, "meta")

--- a/uninstall-profile
+++ b/uninstall-profile
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+from __future__ import print_function
+
+import os
+import sys
+import yaml
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+META_DIR = os.path.join(BASE_DIR, "meta")
+CONFIG_DIR = os.path.join(META_DIR, "configs")
+PROFILES_DIR = os.path.join(META_DIR, "profiles")
+CONFIG_SUFFIX = ".yaml"
+
+
+def remove_links(config_file):
+    with open(config_file, "r") as f:
+        conf = yaml.safe_load(f)
+    if not conf:
+        return
+    for section in conf:
+        if "link" in section:
+            for target in section["link"]:
+                realpath = os.path.expanduser(target)
+                if os.path.islink(realpath):
+                    print("Removing", realpath)
+                    os.unlink(realpath)
+
+
+def resolve_configs(profile):
+    profile_file = os.path.join(PROFILES_DIR, profile)
+    if not os.path.isfile(profile_file):
+        print(f"Error: profile '{profile}' not found", file=sys.stderr)
+        sys.exit(1)
+    with open(profile_file, "r") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+if len(sys.argv) < 2:
+    print(f"Usage: {sys.argv[0]} <profile>", file=sys.stderr)
+    sys.exit(1)
+
+profile = sys.argv[1]
+configs = resolve_configs(profile)
+
+for config in configs:
+    config_file = os.path.join(CONFIG_DIR, config + CONFIG_SUFFIX)
+    if not os.path.isfile(config_file):
+        print(f"Warning: config '{config}' not found, skipping", file=sys.stderr)
+        continue
+    print(f"\nUninstalling {config}")
+    remove_links(config_file)


### PR DESCRIPTION
## Summary
- Splits `ssh.yaml` into three configs: `ssh` (config + known_hosts_fixed), `ssh-authorized` (authorized_keys), and `ssh-known-hosts-ansible` (known_hosts_ansible)
- Removes `DOTBOT_SKIP_*` environment variable conditionals in favour of profile-based selection
- Adds `client` profile for machines that only accept incoming SSH
- Updates `server` and `workstation` profiles to use the new split configs
- Adds `uninstall-profile` script to remove all symlinks for a profile before switching
- Updates README and CLAUDE.md documentation

## Profiles
| Profile | Configs |
|---------|---------|
| `client` | git, ssh-authorized, zsh |
| `server` | git, ssh, ssh-authorized, zsh |
| `workstation` | git, ssh, ssh-known-hosts-ansible, zsh, claude |

## Test plan
- [x] `./uninstall-profile workstation` removes correct symlinks
- [x] `./install-profile workstation` recreates correct symlinks
- [x] `./install-profile server` on a server
- [x] `./install-profile client` on a client machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)