### PR TITLE
Add pr-review-fix skill

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -31,7 +31,7 @@ The `allow` list pre-approves these `gh` tool patterns without prompting. Anythi
 ### `/pr-review-fix` skill
 - `gh api repos/*/pulls/*/comments*` — read inline review comment threads
 - `gh api repos/*/issues/*/comments*` — read general PR/issue comments
-- `gh api -X POST repos/*/pulls/comments/*/replies*` — reply to an inline review thread with a commit hash
+- `gh api -X POST repos/*/pulls/*/comments/*/replies*` — reply to an inline review thread with a commit hash
 - `gh pr comment*` — post general PR comments (replying to non-inline comments)
 
 > GraphQL mutations (e.g. resolving review threads) are intentionally left out so the user is prompted before threads are marked resolved.

--- a/claude/README.md
+++ b/claude/README.md
@@ -1,0 +1,37 @@
+# Claude Code Configuration
+
+This directory is managed by dotbot via `meta/configs/claude.yaml`. Files are symlinked into `~/.claude/`.
+
+## Files
+
+| Source | Destination | Purpose |
+|--------|-------------|---------|
+| `settings.json` | `~/.claude/settings.json` | Claude Code settings and permissions |
+| `CLAUDE.md` | `~/.claude/CLAUDE.md` | Instructions loaded into every session |
+| `statusline-command.sh` | `~/.claude/statusline-command.sh` | Status line command |
+| `skills/` | `~/.claude/skills/` | Personal skills available across all projects |
+
+## skills/
+
+| Skill | Description |
+|-------|-------------|
+| `pr-review-fix` | Work through PR review comments interactively — fix, commit, reply with commit hash, resolve threads |
+
+## settings.json Permissions Reference
+
+The `allow` list pre-approves these `gh` tool patterns without prompting. Anything not listed will prompt the user for approval.
+
+### General GitHub read access
+- `gh pr view/list/checks/diff/status` — inspect PRs
+- `gh issue view/list/status` — inspect issues
+- `gh repo view` — inspect repo metadata
+- `gh run view/list` — inspect CI runs
+- `gh release view/list` — inspect releases
+
+### `/pr-comments` skill
+- `gh api repos/*/pulls/*/comments*` — read inline review comment threads
+- `gh api repos/*/issues/*/comments*` — read general PR/issue comments
+- `gh api -X POST repos/*/pulls/comments/*/replies*` — reply to an inline review thread with a commit hash
+- `gh pr comment*` — post general PR comments (replying to non-inline comments)
+
+> GraphQL mutations (e.g. resolving review threads) are intentionally left out so the user is prompted before threads are marked resolved.

--- a/claude/README.md
+++ b/claude/README.md
@@ -29,9 +29,9 @@ The `allow` list pre-approves these `gh` tool patterns without prompting. Anythi
 - `gh release view/list` — inspect releases
 
 ### `/pr-review-fix` skill
-- `gh api repos/*/pulls/*/comments*` — read inline review comment threads
-- `gh api repos/*/issues/*/comments*` — read general PR/issue comments
+- `gh api -X GET repos/*/pulls/*/comments*` — read inline review comment threads
+- `gh api -X GET repos/*/issues/*/comments*` — read general PR/issue comments
 - `gh api -X POST repos/*/pulls/*/comments/*/replies*` — reply to an inline review thread with a commit hash
-- `gh pr comment*` — post general PR comments (replying to non-inline comments)
+- `gh api -X POST repos/*/issues/*/comments*` — post general PR comments (replying to non-inline comments)
 
 > GraphQL mutations (e.g. resolving review threads) are intentionally left out so the user is prompted before threads are marked resolved.

--- a/claude/README.md
+++ b/claude/README.md
@@ -28,7 +28,7 @@ The `allow` list pre-approves these `gh` tool patterns without prompting. Anythi
 - `gh run view/list` — inspect CI runs
 - `gh release view/list` — inspect releases
 
-### `/pr-comments` skill
+### `/pr-review-fix` skill
 - `gh api repos/*/pulls/*/comments*` — read inline review comment threads
 - `gh api repos/*/issues/*/comments*` — read general PR/issue comments
 - `gh api -X POST repos/*/pulls/comments/*/replies*` — reply to an inline review thread with a commit hash

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -21,7 +21,7 @@
       "Bash(gh api -X GET repos/*/pulls/*/comments*)",
       "Bash(gh api -X GET repos/*/issues/*/comments*)",
       "Bash(gh api -X POST repos/*/pulls/*/comments/*/replies*)",
-      "Bash(gh api -X POST repos/*/issues/*/comments)"
+      "Bash(gh api -X POST repos/*/issues/*/comments*)"
     ]
   }
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -18,10 +18,10 @@
       "Bash(gh run list*)",
       "Bash(gh release view*)",
       "Bash(gh release list*)",
-      "Bash(gh api repos/*/pulls/*/comments*)",
-      "Bash(gh api repos/*/issues/*/comments*)",
+      "Bash(gh api -X GET repos/*/pulls/*/comments*)",
+      "Bash(gh api -X GET repos/*/issues/*/comments*)",
       "Bash(gh api -X POST repos/*/pulls/*/comments/*/replies*)",
-      "Bash(gh pr comment*)"
+      "Bash(gh api -X POST repos/*/issues/*/comments)"
     ]
   }
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -20,7 +20,7 @@
       "Bash(gh release list*)",
       "Bash(gh api repos/*/pulls/*/comments*)",
       "Bash(gh api repos/*/issues/*/comments*)",
-      "Bash(gh api -X POST repos/*/pulls/comments/*/replies*)",
+      "Bash(gh api -X POST repos/*/pulls/*/comments/*/replies*)",
       "Bash(gh pr comment*)"
     ]
   }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -17,7 +17,11 @@
       "Bash(gh run view*)",
       "Bash(gh run list*)",
       "Bash(gh release view*)",
-      "Bash(gh release list*)"
+      "Bash(gh release list*)",
+      "Bash(gh api repos/*/pulls/*/comments*)",
+      "Bash(gh api repos/*/issues/*/comments*)",
+      "Bash(gh api -X POST repos/*/pulls/comments/*/replies*)",
+      "Bash(gh pr comment*)"
     ]
   }
 }

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: pr-review-fix
+description: Work through GitHub PR review comments interactively, one by one. For each comment, implement the fix, commit it, and reply to the comment with the commit hash. At the end, resolve all addressed threads. Use this skill when the user wants to address PR feedback, respond to reviewers, fix review comments, process GitHub PR comments, or work through pull request review threads systematically.
+---
+
+# PR Comments Workflow
+
+Work through a PR's review comments one by one: read each comment, implement the fix, commit it, reply to the comment thread with the commit hash, and resolve addressed threads at the end.
+
+## 1. Identify the PR
+
+If the user provided a PR number or URL, use it. Otherwise:
+
+```bash
+gh pr view --json number,title,headRefName,url
+```
+
+If no open PR is found on the current branch, ask the user for a PR number.
+
+Capture the repo owner/name:
+
+```bash
+gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"'
+```
+
+## 2. Fetch All Comments
+
+### Inline review comments (file-level, with line references)
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
+  --paginate \
+  --jq '[.[] | {id, path, line, original_line, body, user: .user.login, html_url, in_reply_to_id, diff_hunk}]'
+```
+
+Keep only top-level threads: filter out entries where `in_reply_to_id` is non-null — those are existing replies, not new threads to address.
+
+### General PR comments (conversation tab)
+
+```bash
+gh api repos/{owner}/{repo}/issues/{pr_number}/comments \
+  --paginate \
+  --jq '[.[] | {id, body, user: .user.login, html_url, created_at}]'
+```
+
+Skip bot comments (user login ends in `[bot]`).
+
+### Build the work list
+
+Combine the two lists. Show a numbered summary to the user:
+
+```
+Found N comment(s) to address:
+  1. [inline] src/foo.py:42 — @alice: "This variable name is unclear..."
+  2. [inline] tests/test_bar.py:15 — @bob: "Missing edge case for empty input"
+  3. [general] @alice: "Should we add a CHANGELOG entry?"
+```
+
+Ask if the user wants to work through all of them in order, or pick specific ones.
+
+## 3. Interactive Comment Loop
+
+For each comment in the work list:
+
+### Display the comment
+
+```
+══════════════════════════════════════════════
+Comment 1 of N  [inline]
+──────────────────────────────────────────────
+File:    src/foo.py, line 42
+Author:  @alice
+URL:     https://github.com/...
+
+  "This variable name is unclear. Consider renaming `d` to
+   something that describes what it holds."
+
+Diff context:
+  @@ -40,5 +40,5 @@
+     result = []
+  -  d = {}
+  +  ...
+══════════════════════════════════════════════
+```
+
+For inline comments, also read the relevant file section around the referenced line for additional context.
+
+### Prompt the user
+
+Ask: **Address this now, Skip, or Stop?** (`a` / `s` / `q`)
+
+- **Skip**: move to the next comment, record as skipped
+- **Stop**: exit the loop early, go to the summary
+- **Address**: continue below
+
+### Implement the fix
+
+1. Read the relevant file if not already in context.
+2. Analyze the comment and propose a concrete change.
+3. Show the proposed diff and confirm with the user before editing.
+4. Apply the fix using Edit or Write tools.
+
+### Commit the fix
+
+Stage only the files changed for this fix — do not use `git add .` blindly if unrelated changes exist:
+
+```bash
+git add <changed files>
+git status  # confirm what's staged
+git commit -m "$(cat <<'EOF'
+<brief imperative summary of the fix>
+
+Addresses review comment: <comment URL>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+Capture the commit hash immediately:
+
+```bash
+git rev-parse HEAD
+```
+
+### Reply to the comment thread with the commit hash
+
+For **inline review comments**:
+
+```bash
+gh api -X POST \
+  repos/{owner}/{repo}/pulls/comments/{comment_id}/replies \
+  --field body="Fixed in {commit_hash} — <one-line summary of what changed>"
+```
+
+For **general PR comments**, reply as a new comment quoting the original:
+
+```bash
+gh pr comment {pr_number} \
+  --body "> <first line of original comment>
+
+Fixed in {commit_hash} — <one-line summary of what changed>"
+```
+
+Record: `{ comment_id, commit_hash, thread_type }` for the final step.
+
+## 4. Final Summary
+
+After the loop, print a table:
+
+```
+╔══════════════════════════════════════════════════════╗
+║  PR Comments — Session Summary                       ║
+╠══════════════╦═══════════════╦═══════════════════════╣
+║  Addressed   ║  Skipped      ║  Total                ║
+║  3           ║  1            ║  4                    ║
+╠══════════════╩═══════════════╩═══════════════════════╣
+║  Commit log                                          ║
+║  abc1234  Address: rename variable `d` → `data_map` ║
+║  def5678  Address: add empty-input edge case test    ║
+║  ghi9012  Address: add CHANGELOG entry for v1.2      ║
+╚══════════════════════════════════════════════════════╝
+```
+
+## 5. Resolve Addressed Threads
+
+For each inline comment thread that was addressed, offer to mark it resolved on GitHub. This requires GraphQL.
+
+First, get the review thread node IDs:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            comments(first: 1) {
+              nodes { databaseId }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="{owner}" -f repo="{repo}" -F pr={pr_number}
+```
+
+Match each thread's `comments.nodes[0].databaseId` against the `comment_id` values you recorded. For matching threads, resolve them:
+
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }
+' -f threadId="{thread_node_id}"
+```
+
+Ask the user before resolving: "Resolve N addressed thread(s) on GitHub? (y/n)"
+
+## 6. Push (optional)
+
+Ask the user: "Push these commits to the remote branch? (y/n)"
+
+If yes:
+```bash
+git push
+```
+
+## Notes
+
+- Never force-push. If `git push` is rejected, surface the error and ask the user how to proceed.
+- If a commit hook fails, investigate the cause — do not use `--no-verify`.
+- Only stage files directly related to the current fix. If `git status` shows unrelated changes, confirm with the user which files to include.
+- If the user rejects a proposed fix, discuss alternatives before implementing.
+- Skip comments that appear to already have a reply from the current user, unless the user explicitly asks to re-address them.

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -137,8 +137,8 @@ gh api -X POST \
 For **general PR comments**, reply as a new comment quoting the original:
 
 ```bash
-gh pr comment {pr_number} \
-  --body "> <first line of original comment>
+gh api -X POST repos/{owner}/{repo}/issues/{pr_number}/comments \
+  --field body="> <first line of original comment>
 
 Fixed in {commit_hash} — <one-line summary of what changed>"
 ```

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -47,22 +47,27 @@ Skip bot comments (user login ends in `[bot]`).
 
 ### Build the work list
 
-Combine the two lists. Show a numbered summary to the user:
+Combine the two lists. Before presenting it, look for comments that can be addressed in a single fix — for example, the same issue raised in multiple places, or several comments all pointing to the same root cause. Group these together and present them as one item.
+
+Show a numbered summary to the user:
 
 ```
-Found N comment(s) to address:
+Found N comment(s) to address (M items after grouping):
   1. [inline] src/foo.py:42 — @alice: "This variable name is unclear..."
   2. [inline] tests/test_bar.py:15 — @bob: "Missing edge case for empty input"
-  3. [general] @alice: "Should we add a CHANGELOG entry?"
+  3. [inline × 2] src/foo.py:10, src/bar.py:22 — @alice, @bob: "Same pagination issue..." (grouped)
+  4. [general] @alice: "Should we add a CHANGELOG entry?"
 ```
 
 Ask if the user wants to work through all of them in order, or pick specific ones.
 
 ## 3. Interactive Comment Loop
 
-For each comment in the work list:
+For each item in the work list (individual comment or group):
 
 ### Display the comment
+
+For a single comment:
 
 ```
 ══════════════════════════════════════════════
@@ -82,6 +87,8 @@ Diff context:
   +  ...
 ══════════════════════════════════════════════
 ```
+
+For a grouped item, display each comment in the group sequentially, then summarize what the combined fix will cover before proposing it.
 
 For inline comments, also read the relevant file section around the referenced line for additional context.
 
@@ -142,7 +149,9 @@ gh pr comment {pr_number} \
 Fixed in {commit_hash} — <one-line summary of what changed>"
 ```
 
-Record: `{ comment_id, commit_hash, thread_type }` for the final step.
+For **grouped comments**, post a reply to every comment in the group with the same commit hash.
+
+Record: `{ comment_id, commit_hash, thread_type }` for each comment (including all in a group) for the final step.
 
 ## 4. Final Summary
 

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -39,8 +39,8 @@ Keep only top-level threads: filter out entries where `in_reply_to_id` is non-nu
 
 ```bash
 gh api repos/{owner}/{repo}/issues/{pr_number}/comments \
-  --paginate \
-  --jq '[.[] | {id, body, user: .user.login, html_url, created_at}]'
+  --paginate --slurp \
+  --jq '[.[] | .[] | {id, body, user: .user.login, html_url, created_at}]'
 ```
 
 Skip bot comments (user login ends in `[bot]`).

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -28,9 +28,8 @@ gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"'
 ### Inline review comments (file-level, with line references)
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
-  --paginate --slurp \
-  --jq '[.[] | .[] | {id, path, line, original_line, body, user: .user.login, html_url, in_reply_to_id, diff_hunk}]'
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
+  | jq -s '[.[][] | {id, path, line, original_line, body, user: .user.login, html_url, in_reply_to_id, diff_hunk}]'
 ```
 
 Keep only top-level threads: filter out entries where `in_reply_to_id` is non-null — those are existing replies, not new threads to address.
@@ -38,9 +37,8 @@ Keep only top-level threads: filter out entries where `in_reply_to_id` is non-nu
 ### General PR comments (conversation tab)
 
 ```bash
-gh api repos/{owner}/{repo}/issues/{pr_number}/comments \
-  --paginate --slurp \
-  --jq '[.[] | .[] | {id, body, user: .user.login, html_url, created_at}]'
+gh api repos/{owner}/{repo}/issues/{pr_number}/comments --paginate \
+  | jq -s '[.[][] | {id, body, user: .user.login, html_url, created_at}]'
 ```
 
 Skip bot comments (user login ends in `[bot]`).

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -129,7 +129,7 @@ For **inline review comments**:
 
 ```bash
 gh api -X POST \
-  repos/{owner}/{repo}/pulls/comments/{comment_id}/replies \
+  repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   --field body="Fixed in {commit_hash} — <one-line summary of what changed>"
 ```
 

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -29,19 +29,15 @@ gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"'
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
-  | jq -s '[.[][] | {id, path, line, original_line, body, user: .user.login, html_url, in_reply_to_id, diff_hunk}]'
+  | jq -s '[.[][] | select(.in_reply_to_id == null) | {id, path, line, original_line, body, user: .user.login, html_url, diff_hunk}]'
 ```
-
-Keep only top-level threads: filter out entries where `in_reply_to_id` is non-null — those are existing replies, not new threads to address.
 
 ### General PR comments (conversation tab)
 
 ```bash
 gh api repos/{owner}/{repo}/issues/{pr_number}/comments --paginate \
-  | jq -s '[.[][] | {id, body, user: .user.login, html_url, created_at}]'
+  | jq -s '[.[][] | select(.user.login | endswith("[bot]") | not) | {id, body, user: .user.login, html_url, created_at}]'
 ```
-
-Skip bot comments (user login ends in `[bot]`).
 
 ### Build the work list
 

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -169,11 +169,13 @@ For each inline comment thread that was addressed, offer to mark it resolved on 
 First, get the review thread node IDs:
 
 ```bash
+# Repeat with -f cursor="{endCursor}" until pageInfo.hasNextPage is false
 gh api graphql -f query='
-  query($owner: String!, $repo: String!, $pr: Int!) {
+  query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $pr) {
-        reviewThreads(first: 100) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
           nodes {
             id
             isResolved
@@ -185,7 +187,7 @@ gh api graphql -f query='
       }
     }
   }
-' -f owner="{owner}" -f repo="{repo}" -F pr={pr_number}
+' -f owner="{owner}" -f repo="{repo}" -F pr={pr_number} -f cursor=""
 ```
 
 Match each thread's `comments.nodes[0].databaseId` against the `comment_id` values you recorded. For matching threads, resolve them:

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -172,7 +172,7 @@ For each inline comment thread that was addressed, offer to mark it resolved on 
 First, get the review thread node IDs:
 
 ```bash
-# Repeat with -f cursor="{endCursor}" until pageInfo.hasNextPage is false
+# First page — omit cursor so GitHub receives null (not an empty string)
 gh api graphql -f query='
   query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
     repository(owner: $owner, name: $repo) {
@@ -190,7 +190,11 @@ gh api graphql -f query='
       }
     }
   }
-' -f owner="{owner}" -f repo="{repo}" -F pr={pr_number} -f cursor=""
+' -f owner="{owner}" -f repo="{repo}" -F pr={pr_number}
+
+# Subsequent pages — repeat with the endCursor until hasNextPage is false
+gh api graphql -f query='...' \
+  -f owner="{owner}" -f repo="{repo}" -F pr={pr_number} -f cursor="{endCursor}"
 ```
 
 Match each thread's `comments.nodes[0].databaseId` against the `comment_id` values you recorded. For matching threads, resolve them:

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -29,8 +29,8 @@ gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"'
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
-  --paginate \
-  --jq '[.[] | {id, path, line, original_line, body, user: .user.login, html_url, in_reply_to_id, diff_hunk}]'
+  --paginate --slurp \
+  --jq '[.[] | .[] | {id, path, line, original_line, body, user: .user.login, html_url, in_reply_to_id, diff_hunk}]'
 ```
 
 Keep only top-level threads: filter out entries where `in_reply_to_id` is non-null — those are existing replies, not new threads to address.

--- a/claude/skills/pr-review-fix/SKILL.md
+++ b/claude/skills/pr-review-fix/SKILL.md
@@ -28,14 +28,14 @@ gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"'
 ### Inline review comments (file-level, with line references)
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
+gh api -X GET repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
   | jq -s '[.[][] | select(.in_reply_to_id == null) | {id, path, line, original_line, body, user: .user.login, html_url, diff_hunk}]'
 ```
 
 ### General PR comments (conversation tab)
 
 ```bash
-gh api repos/{owner}/{repo}/issues/{pr_number}/comments --paginate \
+gh api -X GET repos/{owner}/{repo}/issues/{pr_number}/comments --paginate \
   | jq -s '[.[][] | select(.user.login | endswith("[bot]") | not) | {id, body, user: .user.login, html_url, created_at}]'
 ```
 

--- a/meta/configs/claude.yaml
+++ b/meta/configs/claude.yaml
@@ -14,3 +14,6 @@
     ~/.claude/statusline-command.sh:
       path: claude/statusline-command.sh
       relink: true
+    ~/.claude/skills:
+      path: claude/skills
+      relink: true


### PR DESCRIPTION
## Summary

- Adds `/pr-review-fix` skill that works through GitHub PR review comments interactively — for each comment it implements the fix, commits it, and replies to the thread with the commit hash
- Links `~/.claude/skills/` to `claude/skills/` in the dotfiles via dotbot so the skill is deployed on install
- Adds scoped `gh api` permissions to `settings.json` for reading PR/issue comments and replying to inline review threads (GraphQL mutations excluded so thread resolution still prompts the user)
- Adds `claude/README.md` documenting the managed files, skills, and permissions allow-list

## Test plan

- [x] Run `./install-standalone claude` and verify `~/.claude/skills` symlink is created
- [x] Open a PR with review comments on another repo and invoke `/pr-review-fix`
- [x] Verify each addressed comment gets a reply with the correct commit hash
- [x] Verify GraphQL resolve step prompts for approval rather than running automatically

🤖 Generated with [Claude Code](https://claude.ai/code)