### PR TITLE
Add fnm zshrc

### DIFF
--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -77,7 +77,7 @@ FNM_PATH="$HOME/.local/share/fnm"
 if [[ -d "$FNM_PATH" ]]; then
   export PATH="$FNM_PATH:$PATH"
   if [[ -z "${XDG_RUNTIME_DIR:-}" || ! -d "$XDG_RUNTIME_DIR" || ! -w "$XDG_RUNTIME_DIR" ]]; then
-    xdg_runtime_dir="/tmp/run/user/$(id -u)"
+    xdg_runtime_dir="/tmp/xdg-runtime-$(id -u)"
     if [[ ! -L "$xdg_runtime_dir" ]]; then
       install -d -m 700 -- "$xdg_runtime_dir"
       if [[ -d "$xdg_runtime_dir" && ! -L "$xdg_runtime_dir" && -O "$xdg_runtime_dir" ]]; then

--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -74,9 +74,9 @@ fi
 # fnm (Node.js version manager)
 # To install: curl -fsSL https://fnm.vercel.app/install | bash
 FNM_PATH="$HOME/.local/share/fnm"
-if [ -d "$FNM_PATH" ]; then
+if [[ -d "$FNM_PATH" ]]; then
   export PATH="$FNM_PATH:$PATH"
-  export XDG_RUNTIME_DIR=/tmp/run/user/$(id -u)
+  export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/run/user/$(id -u)}"
   mkdir -p "$XDG_RUNTIME_DIR"
   eval "$(fnm env --use-on-cd --shell zsh)"
 fi

--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -76,8 +76,15 @@ fi
 FNM_PATH="$HOME/.local/share/fnm"
 if [[ -d "$FNM_PATH" ]]; then
   export PATH="$FNM_PATH:$PATH"
-  export XDG_RUNTIME_DIR="/tmp/run/user/$(id -u)"
-  mkdir -p "$XDG_RUNTIME_DIR"
+  if [[ -z "${XDG_RUNTIME_DIR:-}" || ! -d "$XDG_RUNTIME_DIR" || ! -w "$XDG_RUNTIME_DIR" ]]; then
+    xdg_runtime_dir="/tmp/run/user/$(id -u)"
+    if [[ ! -L "$xdg_runtime_dir" ]]; then
+      install -d -m 700 -- "$xdg_runtime_dir"
+      if [[ -d "$xdg_runtime_dir" && ! -L "$xdg_runtime_dir" && -O "$xdg_runtime_dir" ]]; then
+        export XDG_RUNTIME_DIR="$xdg_runtime_dir"
+      fi
+    fi
+  fi
   eval "$(fnm env --use-on-cd --shell zsh)"
 fi
 

--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -71,6 +71,15 @@ if grep -qi microsoft /proc/version 2>/dev/null; then
   fi
 fi
 
+# fnm (Node.js version manager)
+# To install: curl -fsSL https://fnm.vercel.app/install | bash
+FNM_PATH="$HOME/.local/share/fnm"
+if [ -d "$FNM_PATH" ]; then
+  export PATH="$FNM_PATH:$PATH"
+  export XDG_RUNTIME_DIR=/tmp/run/user/$(id -u)
+  mkdir -p "$XDG_RUNTIME_DIR"
+  eval "$(fnm env --use-on-cd --shell zsh)"
+fi
 
 # https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/ssh-agent
 zstyle :omz:plugins:ssh-agent lazy yes

--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -78,8 +78,10 @@ if [[ -x "$FNM_PATH/fnm" ]]; then
   export PATH="$FNM_PATH:$PATH"
   if [[ -z "${XDG_RUNTIME_DIR:-}" || ! -d "$XDG_RUNTIME_DIR" || ! -w "$XDG_RUNTIME_DIR" ]]; then
     xdg_runtime_dir="/tmp/xdg-runtime-$(id -u)"
-    if [[ ! -L "$xdg_runtime_dir" ]]; then
-      install -d -m 700 -- "$xdg_runtime_dir"
+    if [[ -d "$xdg_runtime_dir" && ! -L "$xdg_runtime_dir" && -O "$xdg_runtime_dir" ]]; then
+      export XDG_RUNTIME_DIR="$xdg_runtime_dir"
+    elif [[ ! -e "$xdg_runtime_dir" ]]; then
+      install -d -m 700 -- "$xdg_runtime_dir" >/dev/null 2>&1
       if [[ -d "$xdg_runtime_dir" && ! -L "$xdg_runtime_dir" && -O "$xdg_runtime_dir" ]]; then
         export XDG_RUNTIME_DIR="$xdg_runtime_dir"
       fi

--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -76,7 +76,7 @@ fi
 FNM_PATH="$HOME/.local/share/fnm"
 if [[ -d "$FNM_PATH" ]]; then
   export PATH="$FNM_PATH:$PATH"
-  export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/run/user/$(id -u)}"
+  export XDG_RUNTIME_DIR="/tmp/run/user/$(id -u)"
   mkdir -p "$XDG_RUNTIME_DIR"
   eval "$(fnm env --use-on-cd --shell zsh)"
 fi

--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -85,7 +85,9 @@ if [[ -d "$FNM_PATH" ]]; then
       fi
     fi
   fi
-  eval "$(fnm env --use-on-cd --shell zsh)"
+  if command -v fnm >/dev/null 2>&1; then
+    eval "$(fnm env --use-on-cd --shell zsh)"
+  fi
 fi
 
 # https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/ssh-agent

--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -74,7 +74,7 @@ fi
 # fnm (Node.js version manager)
 # To install: curl -fsSL https://fnm.vercel.app/install | bash
 FNM_PATH="$HOME/.local/share/fnm"
-if [[ -d "$FNM_PATH" ]]; then
+if [[ -x "$FNM_PATH/fnm" ]]; then
   export PATH="$FNM_PATH:$PATH"
   if [[ -z "${XDG_RUNTIME_DIR:-}" || ! -d "$XDG_RUNTIME_DIR" || ! -w "$XDG_RUNTIME_DIR" ]]; then
     xdg_runtime_dir="/tmp/xdg-runtime-$(id -u)"
@@ -85,9 +85,7 @@ if [[ -d "$FNM_PATH" ]]; then
       fi
     fi
   fi
-  if command -v fnm >/dev/null 2>&1; then
-    eval "$(fnm env --use-on-cd --shell zsh)"
-  fi
+  eval "$(fnm env --use-on-cd --shell zsh)"
 fi
 
 # https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/ssh-agent


### PR DESCRIPTION
  Summary

  - Adds conditional fnm initialization to zshrc, guarded by a check for ~/.local/share/fnm
  - Sets XDG_RUNTIME_DIR to a safe /tmp-based path (WSL2 compatible) and creates it if missing
  - Uses fnm env --use-on-cd for automatic .nvmrc/.node-version switching

  Notes

  fnm must be installed separately via:
  curl -fsSL https://fnm.vercel.app/install | bash

  The setup is a no-op on machines where fnm isn't installed, so this is safe to apply across all profiles.