### PR TITLE
Add apiBase to Continue Windows config for LAN Ollama server

### DIFF
--- a/tools/continue/config.windows.yaml
+++ b/tools/continue/config.windows.yaml
@@ -5,6 +5,7 @@ models:
   - name: Qwen2.5-Coder 14B
     provider: ollama
     model: qwen2.5-coder:14b
+    apiBase: http://10.10.1.100:11434
     roles:
       - chat
       - edit
@@ -12,6 +13,7 @@ models:
   - name: Qwen3.5 9B
     provider: ollama
     model: qwen3.5:9b
+    apiBase: http://10.10.1.100:11434
     roles:
       - chat
       - edit
@@ -19,5 +21,6 @@ models:
   - name: Qwen2.5-Coder 1.5B
     provider: ollama
     model: qwen2.5-coder:1.5b-base
+    apiBase: http://10.10.1.100:11434
     roles:
       - autocomplete


### PR DESCRIPTION
## Summary
- Adds `apiBase: http://10.10.1.100:11434` to all three models in `config.windows.yaml`
- Fixes "unable to connect to local Ollama" error on Windows laptops connecting remotely to the desktop Ollama server
- `config.lan.yaml` (WSL/Linux) was already correct and unchanged

## Test plan
- [x] Copy `config.windows.yaml` to `~/.continue/config.yaml` on a Windows machine
- [x] Confirm Continue connects to Ollama on the LAN server

🤖 Generated with [Claude Code](https://claude.com/claude-code)