### PR TITLE
Add gping and trippy aliases to zshrc

### DIFF
--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -174,6 +174,10 @@ set-title-preexec() {
   echo -ne "\033]0;$title\007"
 }
 
+# Aliases
+command -v gping &>/dev/null && alias ping=gping
+command -v trip &>/dev/null && alias traceroute=trip
+
 # Prompt — switch with PROMPT_THEME=p10k in ~/.zshrc.local (default: starship)
 # To install starship: curl -sS https://starship.rs/install.sh | sh
 # To install p10k:     znap source romkatv/powerlevel10k (handled below)


### PR DESCRIPTION
## Summary
- Aliases `ping` → `gping` and `traceroute` → `trip`
- Both aliases are guarded with `command -v` so they're no-ops on hosts where the tools aren't installed

## Notes
`trip` requires `cap_net_raw` — handle at install time with:
\`\`\`bash
sudo setcap cap_net_raw+ep $(which trip)
\`\`\`

## Test plan
- [ ] Verify `ping` invokes `gping` on a host with gping installed
- [ ] Verify `traceroute` invokes `trip` on a host with trippy installed and setcap applied
- [ ] Verify no errors on hosts without either tool installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)