### PR TITLE
Fix p10k fallback to run with instant prompt support

### DIFF
--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -2,6 +2,13 @@
 # Set PROMPT_THEME=p10k here to switch to Powerlevel10k.
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 
+# If starship is missing and no explicit theme override, fall back to p10k now so
+# the instant-prompt block below and the loader at the bottom share the same path.
+if [[ "${PROMPT_THEME:-starship}" == "starship" ]] && ! command -v starship &>/dev/null; then
+  PROMPT_THEME=p10k
+  echo "[dotfiles] starship not found — using p10k. Install: curl -sS https://starship.rs/install.sh | sh" >&2
+fi
+
 # Show MOTD in WSL — must run before p10k instant prompt (no console output allowed after it).
 if grep -qi microsoft /proc/version 2>/dev/null; then
   if [[ -d /etc/update-motd.d ]]; then
@@ -184,10 +191,6 @@ command -v trip &>/dev/null && alias traceroute=trip
 if [[ "${PROMPT_THEME:-starship}" == "p10k" ]]; then
   znap source romkatv/powerlevel10k
   [[ -f ~/.p10k.zsh ]] && source ~/.p10k.zsh
-elif command -v starship &>/dev/null; then
-  eval "$(starship init zsh)"
 else
-  echo "[dotfiles] starship not found — falling back to p10k. Install: curl -sS https://starship.rs/install.sh | sh" >&2
-  znap source romkatv/powerlevel10k
-  [[ -f ~/.p10k.zsh ]] && source ~/.p10k.zsh
+  eval "$(starship init zsh)"
 fi

--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -192,5 +192,5 @@ if [[ "${PROMPT_THEME:-starship}" == "p10k" ]]; then
   znap source romkatv/powerlevel10k
   [[ -f ~/.p10k.zsh ]] && source ~/.p10k.zsh
 else
-  eval "$(starship init zsh)"
+  eval "$(starship init zsh)"  # starship guaranteed present — fallback to p10k was set above if missing
 fi


### PR DESCRIPTION
## Summary
- Detects missing `starship` binary before the p10k instant-prompt block runs
- Sets `PROMPT_THEME=p10k` early so the fallback path gets full instant-prompt support
- Removes the duplicate fallback `else` branch at the bottom of zshrc — now a single clean code path

## Test plan
- [x] On a host without starship installed, open a new shell and confirm the p10k prompt loads correctly with no visual oddities
- [x] On a host with starship installed, confirm starship prompt still loads as normal
- [x] Confirm `PROMPT_THEME=p10k` in `~/.zshrc.local` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)