### PR TITLE
Rework Claude Code statusline to match starship powerline style

### DIFF
--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -26,6 +26,8 @@ FG_CRUST="\033[38;2;17;17;27m"
 RESET="\033[0m"
 
 ARROW=""
+ROUND_LEFT=""
+ROUND_RIGHT=""
 
 # Shorten home directory to ~, then truncate to last 3 path components
 home_dir="$HOME"
@@ -43,8 +45,11 @@ trunc_dir=$(printf '%s' "$short_dir" | awk -F'/' '{
   print out
 }')
 
-# user@host (host only shown over SSH, matching starship'\''s ssh_only hostname)
-line="${BG_RED}${FG_CRUST}  ${user}"
+# rounded head cap
+# user@host (host only shown over SSH, matching the starship hostname behavior)
+line="${FG_RED}${ROUND_LEFT}${RESET}"
+
+line="${line}${BG_RED}${FG_CRUST}  ${user}"
 if [ -n "$SSH_TTY" ] || [ -n "$SSH_CONNECTION" ]; then
   line="${line}@${host}"
 fi
@@ -123,7 +128,7 @@ if [ -n "$seven_d_pct" ]; then
   prev_fg="$FG_PINK"
 fi
 
-# closing arrow fading to terminal background
-line="${line}${prev_fg}${ARROW}${RESET}"
+# rounded tail cap
+line="${line}${prev_fg}${ROUND_RIGHT}${RESET}"
 
 printf '%b\n' "$line"

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -3,10 +3,13 @@
 # (catppuccin-mocha palette): user@host | dir | git | model | ctx% | time
 input=$(cat)
 
-# Single jq call extracting every field via TSV, instead of one echo|jq fork per field
+# Single jq call extracting every field via TSV, instead of one echo|jq fork per field.
+# Backslashes in the two string fields are doubled so the final `printf '%b'`
+# render step treats them as literal text instead of escape sequences (the
+# numeric fields below can't contain backslashes, so gsub only applies to these two).
 tsv=$(printf '%s' "$input" | jq -r '[
-  .workspace.current_dir,
-  .model.display_name,
+  (.workspace.current_dir | gsub("\\\\"; "\\\\")),
+  (.model.display_name | gsub("\\\\"; "\\\\")),
   (.context_window.used_percentage // ""),
   (.rate_limits.five_hour.used_percentage // ""),
   (.rate_limits.five_hour.resets_at // ""),
@@ -85,7 +88,10 @@ seg "$BG_PEACH" "$trunc_dir" "$FG_PEACH"
 
 # git branch and dirty status (skip optional locks). symbolic-ref/rev-parse
 # already fail outside a repo, so no separate rev-parse --git-dir probe is needed.
+# git itself rejects backslashes in ref names, but double any anyway (defense
+# in depth) so the final `printf '%b'` render step can't reinterpret them.
 if branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || git -C "$dir" rev-parse --short HEAD 2>/dev/null) && [ -n "$branch" ]; then
+  branch=$(printf '%s' "$branch" | sed 's/\\/\\\\/g')
   dirty=$(git --no-optional-locks -C "$dir" status --porcelain 2>/dev/null | head -1)
   if [ -n "$dirty" ]; then
     star=" *"

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -3,12 +3,27 @@
 # (catppuccin-mocha palette): user@host | dir | git | model | ctx% | time
 input=$(cat)
 
-dir=$(echo "$input" | jq -r '.workspace.current_dir')
-model=$(echo "$input" | jq -r '.model.display_name')
-ctx=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
-five_h_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
-five_h_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
-seven_d_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+# Single jq call extracting every field via TSV, instead of one echo|jq fork per field
+tsv=$(printf '%s' "$input" | jq -r '[
+  .workspace.current_dir,
+  .model.display_name,
+  (.context_window.used_percentage // ""),
+  (.rate_limits.five_hour.used_percentage // ""),
+  (.rate_limits.five_hour.resets_at // ""),
+  (.rate_limits.seven_day.used_percentage // "")
+] | join("\u001f")')
+oldifs="$IFS"
+IFS=$(printf '\037')
+set -f
+set -- $tsv
+set +f
+IFS="$oldifs"
+dir=$1
+model=$2
+ctx=$3
+five_h_pct=$4
+five_h_reset=$5
+seven_d_pct=$6
 
 user=$(whoami)
 host=$(hostname -s)
@@ -29,6 +44,14 @@ ARROW=""
 ROUND_LEFT=""
 ROUND_RIGHT=""
 
+# Appends one powerline segment to $line: an arrow fading from the previous
+# segment's color into $1 (this segment's bg), then $1's block containing $2.
+# Updates $prev_fg to $3 so the next segment's arrow fades from this one.
+seg() {
+  line="${line}${prev_fg}${1}${ARROW}${RESET}${1}${FG_CRUST} ${2} ${RESET}"
+  prev_fg="$3"
+}
+
 # Shorten home directory to ~, then truncate to last 3 path components
 home_dir="$HOME"
 short_dir="${dir#$home_dir}"
@@ -46,9 +69,9 @@ trunc_dir=$(printf '%s' "$short_dir" | awk -F'/' '{
 }')
 
 # rounded head cap
-# user@host (host only shown over SSH, matching the starship hostname behavior)
 line="${FG_RED}${ROUND_LEFT}${RESET}"
 
+# user@host (host only shown over SSH, matching the starship hostname behavior)
 line="${line}${BG_RED}${FG_CRUST}  ${user}"
 if [ -n "$SSH_TTY" ] || [ -n "$SSH_CONNECTION" ]; then
   line="${line}@${host}"
@@ -57,54 +80,40 @@ line="${line} ${RESET}"
 prev_fg="$FG_RED"
 
 # directory
-line="${line}${prev_fg}${BG_PEACH}${ARROW}${RESET}"
-line="${line}${BG_PEACH}${FG_CRUST} ${trunc_dir} ${RESET}"
-prev_fg="$FG_PEACH"
+seg "$BG_PEACH" "$trunc_dir" "$FG_PEACH"
 
-# git branch and dirty status (skip optional locks)
-git_in_repo=false
-if git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
-  git_in_repo=true
-  branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || git -C "$dir" rev-parse --short HEAD 2>/dev/null)
+# git branch and dirty status (skip optional locks). symbolic-ref/rev-parse
+# already fail outside a repo, so no separate rev-parse --git-dir probe is needed.
+if branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || git -C "$dir" rev-parse --short HEAD 2>/dev/null) && [ -n "$branch" ]; then
   dirty=$(git --no-optional-locks -C "$dir" status --porcelain 2>/dev/null | head -1)
   if [ -n "$dirty" ]; then
     star=" *"
   else
     star=""
   fi
-fi
-
-if [ "$git_in_repo" = true ]; then
-  line="${line}${prev_fg}${BG_YELLOW}${ARROW}${RESET}"
-  line="${line}${BG_YELLOW}${FG_CRUST}  ${branch}${star} ${RESET}"
-  prev_fg="$FG_YELLOW"
+  seg "$BG_YELLOW" " ${branch}${star}" "$FG_YELLOW"
 fi
 
 # model
-line="${line}${prev_fg}${BG_GREEN}${ARROW}${RESET}"
-line="${line}${BG_GREEN}${FG_CRUST} ${model} ${RESET}"
-prev_fg="$FG_GREEN"
+seg "$BG_GREEN" "$model" "$FG_GREEN"
 
 # context window usage
 if [ -n "$ctx" ]; then
   ctx_rounded=$(printf '%.0f' "$ctx")
-  line="${line}${prev_fg}${BG_SAPPHIRE}${ARROW}${RESET}"
-  line="${line}${BG_SAPPHIRE}${FG_CRUST} ctx:${ctx_rounded}% ${RESET}"
-  prev_fg="$FG_SAPPHIRE"
+  seg "$BG_SAPPHIRE" "ctx:${ctx_rounded}%" "$FG_SAPPHIRE"
 fi
 
-# time
-time_str=$(date '+%I:%M %p')
-line="${line}${prev_fg}${BG_LAVENDER}${ARROW}${RESET}"
-line="${line}${BG_LAVENDER}${FG_CRUST}  ${time_str} ${RESET}"
-prev_fg="$FG_LAVENDER"
+# time (also captures epoch seconds in the same `date` call, for the 5h countdown below)
+date_out=$(date '+%I:%M %p|%s')
+time_str="${date_out%|*}"
+now="${date_out#*|}"
+seg "$BG_LAVENDER" " ${time_str}" "$FG_LAVENDER"
 
 # 5-hour rate limit usage and time left
 if [ -n "$five_h_pct" ]; then
   five_h_rounded=$(printf '%.0f' "$five_h_pct")
   reset_str=""
   if [ -n "$five_h_reset" ]; then
-    now=$(date +%s)
     remaining=$((five_h_reset - now))
     [ "$remaining" -lt 0 ] && remaining=0
     rh=$((remaining / 3600))
@@ -115,17 +124,13 @@ if [ -n "$five_h_pct" ]; then
       reset_str=" (${rm}m left)"
     fi
   fi
-  line="${line}${prev_fg}${BG_MAUVE}${ARROW}${RESET}"
-  line="${line}${BG_MAUVE}${FG_CRUST} 5h:${five_h_rounded}%${reset_str} ${RESET}"
-  prev_fg="$FG_MAUVE"
+  seg "$BG_MAUVE" "5h:${five_h_rounded}%${reset_str}" "$FG_MAUVE"
 fi
 
 # 7-day rate limit usage (compact, percentage only)
 if [ -n "$seven_d_pct" ]; then
   seven_d_rounded=$(printf '%.0f' "$seven_d_pct")
-  line="${line}${prev_fg}${BG_PINK}${ARROW}${RESET}"
-  line="${line}${BG_PINK}${FG_CRUST} 7d:${seven_d_rounded}% ${RESET}"
-  prev_fg="$FG_PINK"
+  seg "$BG_PINK" "7d:${seven_d_rounded}%" "$FG_PINK"
 fi
 
 # rounded tail cap

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -1,12 +1,33 @@
 #!/bin/sh
-# Claude Code status line — mirrors p10k prompt: user@host dir [git] | model ctx%
+# Claude Code status line — powerline style mirroring the starship prompt
+# (catppuccin-mocha palette): user@host | dir | git | model | ctx% | time
 input=$(cat)
+
+dir=$(echo "$input" | jq -r '.workspace.current_dir')
+model=$(echo "$input" | jq -r '.model.display_name')
+ctx=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+five_h_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+five_h_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+seven_d_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
 
 user=$(whoami)
 host=$(hostname -s)
-dir=$(echo "$input" | jq -r '.workspace.current_dir')
 
-# Shorten home directory to ~
+# catppuccin-mocha colors, matching shells/starship/starship.toml
+BG_RED="\033[48;2;243;139;168m";      FG_RED="\033[38;2;243;139;168m"
+BG_PEACH="\033[48;2;250;179;135m";    FG_PEACH="\033[38;2;250;179;135m"
+BG_YELLOW="\033[48;2;249;226;175m";   FG_YELLOW="\033[38;2;249;226;175m"
+BG_GREEN="\033[48;2;166;227;161m";    FG_GREEN="\033[38;2;166;227;161m"
+BG_SAPPHIRE="\033[48;2;116;199;236m"; FG_SAPPHIRE="\033[38;2;116;199;236m"
+BG_LAVENDER="\033[48;2;180;190;254m"; FG_LAVENDER="\033[38;2;180;190;254m"
+BG_MAUVE="\033[48;2;203;166;247m";    FG_MAUVE="\033[38;2;203;166;247m"
+BG_PINK="\033[48;2;245;194;231m";     FG_PINK="\033[38;2;245;194;231m"
+FG_CRUST="\033[38;2;17;17;27m"
+RESET="\033[0m"
+
+ARROW=""
+
+# Shorten home directory to ~, then truncate to last 3 path components
 home_dir="$HOME"
 short_dir="${dir#$home_dir}"
 if [ "$short_dir" != "$dir" ]; then
@@ -14,26 +35,95 @@ if [ "$short_dir" != "$dir" ]; then
 else
   short_dir="$dir"
 fi
+trunc_dir=$(printf '%s' "$short_dir" | awk -F'/' '{
+  n = NF
+  if (n <= 3) { print; next }
+  out = "\xe2\x80\xa6"
+  for (i = n - 2; i <= n; i++) out = out "/" $i
+  print out
+}')
 
-# Git branch and dirty status (skip optional locks)
-git_info=""
+# user@host (host only shown over SSH, matching starship'\''s ssh_only hostname)
+line="${BG_RED}${FG_CRUST}  ${user}"
+if [ -n "$SSH_TTY" ] || [ -n "$SSH_CONNECTION" ]; then
+  line="${line}@${host}"
+fi
+line="${line} ${RESET}"
+prev_fg="$FG_RED"
+
+# directory
+line="${line}${prev_fg}${BG_PEACH}${ARROW}${RESET}"
+line="${line}${BG_PEACH}${FG_CRUST} ${trunc_dir} ${RESET}"
+prev_fg="$FG_PEACH"
+
+# git branch and dirty status (skip optional locks)
+git_in_repo=false
 if git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
+  git_in_repo=true
   branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || git -C "$dir" rev-parse --short HEAD 2>/dev/null)
-  dirty=$(git -C "$dir" status --porcelain --no-optional-locks 2>/dev/null | head -1)
+  dirty=$(git --no-optional-locks -C "$dir" status --porcelain 2>/dev/null | head -1)
   if [ -n "$dirty" ]; then
-    git_info=" [$branch *]"
+    star=" *"
   else
-    git_info=" [$branch]"
+    star=""
   fi
 fi
 
-# Model and context
-model=$(echo "$input" | jq -r '.model.display_name')
-ctx=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
-if [ -n "$ctx" ]; then
-  ctx_display=" | ctx:$(printf '%.0f' "$ctx")%"
-else
-  ctx_display=""
+if [ "$git_in_repo" = true ]; then
+  line="${line}${prev_fg}${BG_YELLOW}${ARROW}${RESET}"
+  line="${line}${BG_YELLOW}${FG_CRUST}  ${branch}${star} ${RESET}"
+  prev_fg="$FG_YELLOW"
 fi
 
-printf '%s@%s %s%s | %s%s' "$user" "$host" "$short_dir" "$git_info" "$model" "$ctx_display"
+# model
+line="${line}${prev_fg}${BG_GREEN}${ARROW}${RESET}"
+line="${line}${BG_GREEN}${FG_CRUST} ${model} ${RESET}"
+prev_fg="$FG_GREEN"
+
+# context window usage
+if [ -n "$ctx" ]; then
+  ctx_rounded=$(printf '%.0f' "$ctx")
+  line="${line}${prev_fg}${BG_SAPPHIRE}${ARROW}${RESET}"
+  line="${line}${BG_SAPPHIRE}${FG_CRUST} ctx:${ctx_rounded}% ${RESET}"
+  prev_fg="$FG_SAPPHIRE"
+fi
+
+# time
+time_str=$(date '+%I:%M %p')
+line="${line}${prev_fg}${BG_LAVENDER}${ARROW}${RESET}"
+line="${line}${BG_LAVENDER}${FG_CRUST}  ${time_str} ${RESET}"
+prev_fg="$FG_LAVENDER"
+
+# 5-hour rate limit usage and time left
+if [ -n "$five_h_pct" ]; then
+  five_h_rounded=$(printf '%.0f' "$five_h_pct")
+  reset_str=""
+  if [ -n "$five_h_reset" ]; then
+    now=$(date +%s)
+    remaining=$((five_h_reset - now))
+    [ "$remaining" -lt 0 ] && remaining=0
+    rh=$((remaining / 3600))
+    rm=$(((remaining % 3600) / 60))
+    if [ "$rh" -gt 0 ]; then
+      reset_str=" (${rh}h${rm}m left)"
+    else
+      reset_str=" (${rm}m left)"
+    fi
+  fi
+  line="${line}${prev_fg}${BG_MAUVE}${ARROW}${RESET}"
+  line="${line}${BG_MAUVE}${FG_CRUST} 5h:${five_h_rounded}%${reset_str} ${RESET}"
+  prev_fg="$FG_MAUVE"
+fi
+
+# 7-day rate limit usage (compact, percentage only)
+if [ -n "$seven_d_pct" ]; then
+  seven_d_rounded=$(printf '%.0f' "$seven_d_pct")
+  line="${line}${prev_fg}${BG_PINK}${ARROW}${RESET}"
+  line="${line}${BG_PINK}${FG_CRUST} 7d:${seven_d_rounded}% ${RESET}"
+  prev_fg="$FG_PINK"
+fi
+
+# closing arrow fading to terminal background
+line="${line}${prev_fg}${ARROW}${RESET}"
+
+printf '%b\n' "$line"

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -62,9 +62,10 @@ else
 fi
 trunc_dir=$(printf '%s' "$short_dir" | awk -F'/' '{
   n = NF
+  if ($1 == "") n = n - 1
   if (n <= 3) { print; next }
   out = "\xe2\x80\xa6"
-  for (i = n - 2; i <= n; i++) out = out "/" $i
+  for (i = NF - 2; i <= NF; i++) out = out "/" $i
   print out
 }')
 


### PR DESCRIPTION
## Summary
- Replaces the plain `user@host dir [git] | model ctx%` statusline with a powerline-style bar mirroring `shells/starship/starship.toml`'s catppuccin-mocha theme: same colors, arrow separators, Nerd Font icons, and rounded pill-shaped head/tail caps.
- Adds 5-hour and 7-day rate limit usage segments (Pro/Max only; segments are omitted entirely when the fields are absent), with time-to-reset shown for the 5-hour window.
- Fixes a latent bug where `--no-optional-locks` was passed after `git status` instead of as a global flag, which silently errored and meant the dirty-repo `*` indicator never actually worked.
- `/simplify` pass: collapsed six `echo|jq` subprocess forks into a single `jq` call (TSV via unit separator), removed a redundant `git rev-parse --git-dir` probe, merged two `date` calls, and extracted the repeated "arrow + colored block" pattern into a `seg()` helper.
- `/security-review` pass: one candidate finding (terminal escape-sequence injection via `printf '%b'` rendering an unsanitized directory name) was raised and run through false-positive filtering — it landed at 7/10 confidence, below the reporting bar, due to the multi-step attacker+victim chain required. No qualifying findings.

## Test plan
- [x] `sh -n` syntax check
- [x] Rendered with mock JSON across: dirty/clean git repo, non-git directory, missing rate-limit fields, five_hour present without `resets_at`, simulated SSH session (hostname only shows over SSH, matching starship's `ssh_only`)
- [x] Confirmed dirty-repo `*` indicator now appears (previously silently broken)
- [x] Re-verified all scenarios after the `/simplify` pass to confirm behavior is unchanged