### PR TITLE
Improve pr-review.sh and update local LLM model list

### DIFF
--- a/ai/models.txt
+++ b/ai/models.txt
@@ -3,9 +3,10 @@
 # Lines starting with # and blank lines are ignored.
 
 deepseek-r1:8b
-llama3.1:8b
-llama3.2:latest
+devstral-small-2:24b
+llama3.2:3b
 nomic-embed-text:latest
 qwen2.5-coder:1.5b-base
 qwen2.5-coder:14b
+qwen3:8b
 qwen3.5:9b

--- a/ai/models.txt
+++ b/ai/models.txt
@@ -8,5 +8,5 @@ llama3.2:3b
 nomic-embed-text:latest
 qwen2.5-coder:1.5b-base
 qwen2.5-coder:14b
-qwen3:8b
+qwen3.6:35b-a3b
 qwen3.5:9b

--- a/ai/prompts/pr-review.md
+++ b/ai/prompts/pr-review.md
@@ -1,1 +1,21 @@
-You are a senior developer doing a code review. Review this PR diff for: security issues, bugs, code quality, and anything suspicious or wrong. Be concise and specific.
+You are a code reviewer. You will be given a PR diff. Your ONLY job is to find problems.
+
+Look for:
+- Bugs, logic errors, or incorrect behavior
+- Security issues (exposed secrets, insecure defaults, overly broad permissions)
+- Inconsistencies within the diff (e.g. a variable defined but used differently elsewhere in the same change)
+- Missing pieces that the changes imply but don't include
+- Things that will break or cause issues
+
+Rules:
+- Do NOT explain what the code does
+- Do NOT describe what each file change is for
+- Do NOT write tutorials or how-to guides
+- Do NOT repeat back the diff
+- Only write findings. If you find nothing wrong with a file, say nothing about it.
+- If you find no issues at all, say "No issues found."
+
+Format each finding as:
+**[file]** — brief description of the problem
+
+End with one short paragraph summarizing overall quality.

--- a/bin/pr-review.sh
+++ b/bin/pr-review.sh
@@ -14,7 +14,7 @@ if ! command -v gh &>/dev/null; then
 fi
 
 if [[ -z "${1:-}" ]]; then
-  echo "Usage: pr-review.sh <PR_NUMBER>" >&2
+  echo "Usage: pr-review.sh <PR_NUMBER> [-- ':!<glob>' ...]" >&2
   exit 1
 fi
 
@@ -28,9 +28,26 @@ if [[ ! -f "$PROMPT_FILE" ]]; then
   exit 1
 fi
 
+# Parse ':!glob' exclusion args into filterdiff --exclude flags
+EXCLUDE_ARGS=()
+for arg in "$@"; do
+  if [[ "$arg" == ":!"* ]]; then
+    EXCLUDE_ARGS+=("--exclude=${arg#:!}")
+  fi
+done
+
 DIFF_FILE=$(mktemp)
 trap "rm -f '$DIFF_FILE'" EXIT
-gh pr diff "$PR_NUMBER" > "$DIFF_FILE"
+
+if [[ ${#EXCLUDE_ARGS[@]} -gt 0 ]]; then
+  if ! command -v filterdiff &>/dev/null; then
+    echo "Error: filterdiff is required for file exclusion. Install with: sudo apt install patchutils" >&2
+    exit 1
+  fi
+  gh pr diff "$PR_NUMBER" | filterdiff "${EXCLUDE_ARGS[@]}" > "$DIFF_FILE"
+else
+  gh pr diff "$PR_NUMBER" > "$DIFF_FILE"
+fi
 
 SECONDS=0
 jq -n \

--- a/bin/pr-review.sh
+++ b/bin/pr-review.sh
@@ -51,19 +51,17 @@ done
 
 DIFF_FILE=$(mktemp)
 RESPONSE_FILE=$(mktemp)
-trap "rm -f '$DIFF_FILE' '$RESPONSE_FILE'" EXIT
+trap 'rm -f "$DIFF_FILE" "$RESPONSE_FILE"' EXIT
 
 if [[ ${#EXCLUDE_ARGS[@]} -gt 0 ]]; then
   if ! command -v filterdiff &>/dev/null; then
     echo "Error: filterdiff is required for file exclusion. Install with: sudo apt install patchutils" >&2
     exit 1
   fi
-  gh pr diff "$PR_NUMBER" | filterdiff "${EXCLUDE_ARGS[@]}" > "$DIFF_FILE"
+  gh pr diff "$PR_NUMBER" | filterdiff "${EXCLUDE_ARGS[@]}"
 else
-  gh pr diff "$PR_NUMBER" > "$DIFF_FILE"
-fi
-
-printf "Reviewing PR #%s with %s " "$PR_NUMBER" "$OLLAMA_MODEL" >&2
+  gh pr diff "$PR_NUMBER"
+fi > "$DIFF_FILE"
 
 SECONDS=0
 jq -n \
@@ -76,9 +74,10 @@ jq -n \
 > "$RESPONSE_FILE" &
 CURL_PID=$!
 
+SPIN_PREFIX="Reviewing PR #${PR_NUMBER} with ${OLLAMA_MODEL}"
 SPINSTR='|/-\'
 while kill -0 "$CURL_PID" 2>/dev/null; do
-  printf "\rReviewing PR #%s with %s %s" "$PR_NUMBER" "$OLLAMA_MODEL" "${SPINSTR:0:1}" >&2
+  printf "\r%s %s" "$SPIN_PREFIX" "${SPINSTR:0:1}" >&2
   SPINSTR="${SPINSTR:1}${SPINSTR:0:1}"
   sleep 0.2
 done

--- a/bin/pr-review.sh
+++ b/bin/pr-review.sh
@@ -18,6 +18,9 @@ if [[ -z "${1:-}" ]]; then
   exit 1
 fi
 
+PR_NUMBER="$1"
+shift
+
 PROMPTS_DIR="${PROMPTS_DIR:-$HOME/ai/prompts}"
 PROMPT_FILE="$PROMPTS_DIR/pr-review.md"
 if [[ ! -f "$PROMPT_FILE" ]]; then
@@ -25,17 +28,18 @@ if [[ ! -f "$PROMPT_FILE" ]]; then
   exit 1
 fi
 
-DIFF=$(gh pr diff "$1")
-SYSTEM_PROMPT=$(cat "$PROMPT_FILE")
+DIFF_FILE=$(mktemp)
+trap "rm -f '$DIFF_FILE'" EXIT
+gh pr diff "$PR_NUMBER" > "$DIFF_FILE"
 
 SECONDS=0
-curl -s "${OLLAMA_BASE_URL}/api/generate" \
-  -d "$(jq -n \
-    --arg model "$OLLAMA_MODEL" \
-    --arg system "$SYSTEM_PROMPT" \
-    --arg prompt "$DIFF" \
-    --argjson stream false \
-    '{model: $model, system: $system, prompt: $prompt, stream: $stream}')" \
-| jq -r '.response'
+jq -n \
+  --arg model "$OLLAMA_MODEL" \
+  --rawfile system "$PROMPT_FILE" \
+  --rawfile prompt "$DIFF_FILE" \
+  --argjson stream false \
+  '{model: $model, system: $system, prompt: $prompt, stream: $stream}' \
+| curl -s -H 'Content-Type: application/json' "${OLLAMA_BASE_URL}/api/generate" --data @- \
+| jq -r 'if .error then "Error: \(.error)" | halt_error(1) else .response end'
 echo "" >&2
 echo "Model: ${OLLAMA_MODEL}  Time: ${SECONDS}s" >&2

--- a/bin/pr-review.sh
+++ b/bin/pr-review.sh
@@ -58,7 +58,7 @@ if [[ ${#EXCLUDE_ARGS[@]} -gt 0 ]]; then
     echo "Error: filterdiff is required for file exclusion. Install with: sudo apt install patchutils" >&2
     exit 1
   fi
-  gh pr diff "$PR_NUMBER" | filterdiff "${EXCLUDE_ARGS[@]}"
+  gh pr diff "$PR_NUMBER" | filterdiff "${EXCLUDE_ARGS[@]}" || { echo "Error: filterdiff failed" >&2; exit 1; }
 else
   gh pr diff "$PR_NUMBER"
 fi > "$DIFF_FILE"

--- a/bin/pr-review.sh
+++ b/bin/pr-review.sh
@@ -37,7 +37,8 @@ for arg in "$@"; do
 done
 
 DIFF_FILE=$(mktemp)
-trap "rm -f '$DIFF_FILE'" EXIT
+RESPONSE_FILE=$(mktemp)
+trap "rm -f '$DIFF_FILE' '$RESPONSE_FILE'" EXIT
 
 if [[ ${#EXCLUDE_ARGS[@]} -gt 0 ]]; then
   if ! command -v filterdiff &>/dev/null; then
@@ -49,6 +50,8 @@ else
   gh pr diff "$PR_NUMBER" > "$DIFF_FILE"
 fi
 
+printf "Reviewing PR #%s with %s " "$PR_NUMBER" "$OLLAMA_MODEL" >&2
+
 SECONDS=0
 jq -n \
   --arg model "$OLLAMA_MODEL" \
@@ -57,6 +60,18 @@ jq -n \
   --argjson stream false \
   '{model: $model, system: $system, prompt: $prompt, stream: $stream}' \
 | curl -s -H 'Content-Type: application/json' "${OLLAMA_BASE_URL}/api/generate" --data @- \
-| jq -r 'if .error then "Error: \(.error)" | halt_error(1) else .response end'
+> "$RESPONSE_FILE" &
+CURL_PID=$!
+
+SPINSTR='|/-\'
+while kill -0 "$CURL_PID" 2>/dev/null; do
+  printf "\rReviewing PR #%s with %s %s" "$PR_NUMBER" "$OLLAMA_MODEL" "${SPINSTR:0:1}" >&2
+  SPINSTR="${SPINSTR:1}${SPINSTR:0:1}"
+  sleep 0.2
+done
+wait "$CURL_PID"
+printf "\r\033[K" >&2
+
+jq -r 'if .error then "Error: \(.error)" | halt_error(1) else .response end' "$RESPONSE_FILE"
 echo "" >&2
 echo "Model: ${OLLAMA_MODEL}  Time: ${SECONDS}s" >&2

--- a/bin/pr-review.sh
+++ b/bin/pr-review.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+# pr-review.sh - Review a GitHub pull request using a local Ollama model
+#
+# Usage: pr-review.sh <PR_NUMBER> [-- ':!<glob>' ...]
+#
+# Arguments:
+#   PR_NUMBER      GitHub pull request number
+#   -- ':!<glob>'  Exclude files matching glob from the diff (repeatable)
+#                  Examples: ':!*.json'  ':!package-lock.json'
+#
+# Environment variables:
+#   OLLAMA_BASE_URL  Base URL of the Ollama API (required)
+#   OLLAMA_MODEL     Model to use (default: qwen2.5-coder:14b)
+#   PROMPTS_DIR      Directory containing pr-review.md prompt (default: ~/ai/prompts)
 set -euo pipefail
 
 OLLAMA_BASE_URL="${OLLAMA_BASE_URL:?OLLAMA_BASE_URL not set — export it in zshrc}"

--- a/tools/continue/config.lan.yaml
+++ b/tools/continue/config.lan.yaml
@@ -1,7 +1,15 @@
 models:
+  - title: Devstral Small 24B
+    provider: ollama
+    model: devstral-small-2:24b
+    apiBase: http://10.10.1.100:11434
   - title: Qwen2.5 Coder 14B
     provider: ollama
     model: qwen2.5-coder:14b
+    apiBase: http://10.10.1.100:11434
+  - title: Qwen3 8B
+    provider: ollama
+    model: qwen3:8b
     apiBase: http://10.10.1.100:11434
   - title: Qwen3.5 9B
     provider: ollama

--- a/tools/continue/config.lan.yaml
+++ b/tools/continue/config.lan.yaml
@@ -1,23 +1,42 @@
+name: Local Config
+version: 1.0.0
+schema: v1
 models:
-  - title: Devstral Small 24B
+  - name: Devstral Small 24B
     provider: ollama
     model: devstral-small-2:24b
     apiBase: http://10.10.1.100:11434
-  - title: Qwen2.5 Coder 14B
+    roles:
+      - chat
+      - edit
+      - apply
+  - name: Qwen2.5-Coder 14B
     provider: ollama
     model: qwen2.5-coder:14b
     apiBase: http://10.10.1.100:11434
-  - title: Qwen3.6 35B-A3B
+    roles:
+      - chat
+      - edit
+      - apply
+  - name: Qwen3.6 35B-A3B
     provider: ollama
     model: qwen3.6:35b-a3b
     apiBase: http://10.10.1.100:11434
-  - title: Qwen3.5 9B
+    roles:
+      - chat
+      - edit
+      - apply
+  - name: Qwen3.5 9B
     provider: ollama
     model: qwen3.5:9b
     apiBase: http://10.10.1.100:11434
-
-tabAutocompleteModel:
-  title: Qwen2.5 Coder 1.5B
-  provider: ollama
-  model: qwen2.5-coder:1.5b-base
-  apiBase: http://10.10.1.100:11434
+    roles:
+      - chat
+      - edit
+      - apply
+  - name: Qwen2.5-Coder 1.5B
+    provider: ollama
+    model: qwen2.5-coder:1.5b-base
+    apiBase: http://10.10.1.100:11434
+    roles:
+      - autocomplete

--- a/tools/continue/config.lan.yaml
+++ b/tools/continue/config.lan.yaml
@@ -7,9 +7,9 @@ models:
     provider: ollama
     model: qwen2.5-coder:14b
     apiBase: http://10.10.1.100:11434
-  - title: Qwen3 8B
+  - title: Qwen3.6 35B-A3B
     provider: ollama
-    model: qwen3:8b
+    model: qwen3.6:35b-a3b
     apiBase: http://10.10.1.100:11434
   - title: Qwen3.5 9B
     provider: ollama

--- a/tools/continue/config.windows.yaml
+++ b/tools/continue/config.windows.yaml
@@ -2,9 +2,25 @@ name: Local Config
 version: 1.0.0
 schema: v1
 models:
+  - name: Devstral Small 24B
+    provider: ollama
+    model: devstral-small-2:24b
+    apiBase: http://10.10.1.100:11434
+    roles:
+      - chat
+      - edit
+      - apply
   - name: Qwen2.5-Coder 14B
     provider: ollama
     model: qwen2.5-coder:14b
+    apiBase: http://10.10.1.100:11434
+    roles:
+      - chat
+      - edit
+      - apply
+  - name: Qwen3 8B
+    provider: ollama
+    model: qwen3:8b
     apiBase: http://10.10.1.100:11434
     roles:
       - chat

--- a/tools/continue/config.windows.yaml
+++ b/tools/continue/config.windows.yaml
@@ -18,9 +18,9 @@ models:
       - chat
       - edit
       - apply
-  - name: Qwen3 8B
+  - name: Qwen3.6 35B-A3B
     provider: ollama
-    model: qwen3:8b
+    model: qwen3.6:35b-a3b
     apiBase: http://10.10.1.100:11434
     roles:
       - chat


### PR DESCRIPTION
## Summary

- Fix `Argument list too long` errors on large PR diffs by using temp files and `jq --rawfile` instead of shell args
- Add file exclusion support (`-- ':!*.json'`) via `filterdiff` (requires `patchutils`)
- Add spinner progress indicator while waiting for Ollama inference
- Add usage comment block to script header
- Rewrite `pr-review.md` prompt to produce issue-focused reviews instead of change summaries
- Update `ai/models.txt`: drop outdated/redundant models, add `devstral-small-2:24b` and `qwen3.6:35b-a3b`
- Update Continue configs to match new model list

## Test plan

- [x] Run `pr-review.sh <PR>` on a large PR to confirm no ARG_MAX error
- [x] Run `pr-review.sh <PR> -- ':!*.json'` to confirm file exclusion works (requires `sudo apt install patchutils`)
- [x] Confirm spinner appears and clears cleanly during inference
- [x] Pull new models via `ollama-sync.sh` and test `devstral-small-2:24b` and `qwen3.6:35b-a3b` in Continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)